### PR TITLE
refactor: allow external PRs & 2 review states

### DIFF
--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -4,33 +4,85 @@
 
 name: Add pull requests to the overview board
 
-on: [pull_request, pull_request_target, pull_request_review]
+on:
+  workflow_run:
+    workflows: [Prepare PR data]
+    types: [completed]
 
 env:
-  todo: Todo
-  in_progress: In Progress
+  todo: Pending
+  changes_requested: Changes Requested
+  approved: Approved
 
 jobs:
   github-actions-automate-projects:
     runs-on: ubuntu-latest
-
-    if: ${{ (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') || (github.actor == 'dependabot[bot]' && github.event_name == 'pull_request_target') }}
     steps:
+      # Data retrieval steps in case of a PR event
+      - name: Download PR data artifact
+        if: github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: Prepare PR data
+          run_id: ${{ github.event.workflow_run.id }}
+          name: PR_DATA
+      - name: Read PR event's PR_NODE_ID.txt
+        if: github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target'
+        id: pr_node_id
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./PR_NODE_ID.txt
+      - name: Read PR event's EVENT_ACTION.txt
+        if: github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target'
+        id: event_action
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./EVENT_ACTION.txt
+      # Data retrieval steps in case of a PR review event
+      - name: Download PR review data artifact
+        if: github.event.workflow_run.event == 'pull_request_review'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: Prepare PR data
+          run_id: ${{ github.event.workflow_run.id }}
+          name: REVIEW_DATA
+      - name: Read PR review event's PR_NODE_ID.txt
+        if: github.event.workflow_run.event == 'pull_request_review'
+        id: pr_node_id
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./PR_NODE_ID.txt
+      - name: Read PR review event's REVIEW_STATE.txt
+        if: github.event.workflow_run.event == 'pull_request_review'
+        id: review_state
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./REVIEW_STATE.txt
+      # Project automation steps
       - name: Move PR to ${{ env.todo }}
-        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (github.event.action == 'opened' || github.event.action == 'reopened')
+        if: (github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target') && (steps.event_action.outputs.content == 'opened' || steps.event_action.outputs.content == 'reopened')
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
         with:
           project_id: 7
           gh_token: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
           organization: openscd
-          resource_node_id: ${{ github.event.pull_request.node_id }}
-          status_value: ${{ env.todo }} # Target status
-      - name: Move PR to ${{env.in_progress}}
-        if: github.event.review.state == 'approved' || github.event.review.state == 'changes_requested'
+          resource_node_id: ${{ steps.pr_node_id.outputs.content }}
+          status_value: ${{ env.todo }}
+      - name: Move PR to ${{env.approved}}
+        if: github.event.workflow_run.event == 'pull_request_review' && steps.review_state.outputs.content == 'approved'
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
         with:
           project_id: 7
           gh_token: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
           organization: openscd
-          resource_node_id: ${{ github.event.pull_request.node_id }}
-          status_value: ${{ env.in_progress }} # Target status
+          resource_node_id: ${{ steps.pr_node_id.outputs.content }}
+          status_value: ${{ env.approved }}
+      - name: Move PR to ${{env.changes_requested}}
+        if: github.event.workflow_run.event == 'pull_request_review' && steps.review_state.outputs.content == 'changes_requested'
+        uses: leonsteinhaeuser/project-beta-automations@v2.1.0
+        with:
+          project_id: 7
+          gh_token: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
+          organization: openscd
+          resource_node_id: ${{ steps.pr_node_id.outputs.content }}
+          status_value: ${{ env.changes_requested }}

--- a/.github/workflows/save-pr-data-to-file.yml
+++ b/.github/workflows/save-pr-data-to-file.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2023 Alliander N.V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Prepare PR data
+# Necessary step to allow adding external PRs to the project board
+
+on: [pull_request, pull_request_target, pull_request_review]
+
+jobs:
+  save-pr-data:
+    name: Save PR data to file
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') || (github.actor == 'dependabot[bot]' && github.event_name == 'pull_request_target') }}
+    steps:
+      - name: Save PR node_id and event_action to files
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        run: echo ${{ github.event.pull_request.node_id }} > PR_NODE_ID.txt && echo ${{ github.event.action }} > EVENT_ACTION.txt
+      - name: Archive PR node_id and event_action
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        uses: actions/upload-artifact@v3
+        with:
+          name: PR_DATA
+          path: |
+            PR_NODE_ID.txt
+            EVENT_ACTION.txt
+      - name: Save PR node_id and review_state to files
+        if: github.event_name == 'pull_request_review'
+        run: echo ${{ github.event.pull_request.node_id }} > PR_NODE_ID.txt && echo ${{ github.event.review.state }} > REVIEW_STATE.txt
+      - name: Archive PR and review_state
+        if: github.event_name == 'pull_request_review'
+        uses: actions/upload-artifact@v3
+        with:
+          name: REVIEW_DATA
+          path: |
+            PR_NODE_ID.txt
+            REVIEW_STATE.txt


### PR DESCRIPTION
I believe that in the same way that we had to merge a first time the refactor before the `Sonarcloud Analysis` action ran successfully on PRs, this PR will need to be merged in order for the `Add pull requests to the overview board` action to run on subsequent PRs